### PR TITLE
remove default_aes StatTextcircle.R

### DIFF
--- a/R/StatTextcircle.R
+++ b/R/StatTextcircle.R
@@ -32,9 +32,5 @@ StatTextcircle <- ggplot2::ggproto(
   `_class` = "StatTextcircle",
   `_inherit` = ggplot2::Stat,
   required_aes = c("label"),
-  compute_panel = compute_panel_textcircle,
-  default_aes = ggplot2::aes(
-    x = ggplot2::after_stat(x),
-    y = ggplot2::after_stat(y)
-  )
+  compute_panel = compute_panel_textcircle
 )


### PR DESCRIPTION
I don't think you should need the default_aes for x and y because they are 'hard coded' in the compute.